### PR TITLE
Now outputs multi-plots

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -1,90 +1,89 @@
 from point import Point, add_points, scale_point, invert_point
 
 def null_filter():
-	"""Filter which returns points as-is"""
-	def process(new_data):
-		return new_data
-	return process
+    """Filter which returns points as-is"""
+    def process(new_data):
+        return new_data
+    return process
 
 
 def fir_filter(weights):
-	"""Returns a FIR filter with the specified weights.
-	Ie if you pass in the weights [0.3, 0.5, 0.2], and pass in an 
-	inpulse ([1, 0, 0]), you will get out the weights as a result"""
-	history = []
-	def process(new_data):
-		nonlocal history
-		history.append(new_data)
-		
-		if len(history) > len(weights):
-			history = history[-len(weights):]
-		
-		p_sum = Point(0, 0)
-		for point, weight in zip(reversed(history), weights):
-			p_sum = add_points(p_sum, scale_point(point, weight))
-			
-		return p_sum
+    """Returns a FIR filter with the specified weights.
+    Ie if you pass in the weights [0.3, 0.5, 0.2], and pass in an
+    inpulse ([1, 0, 0]), you will get out the weights as a result"""
+    history = []
+    def process(new_data):
+        nonlocal history
+        history.append(new_data)
 
-	return process
-	
+        if len(history) > len(weights):
+            history = history[-len(weights):]
+
+        p_sum = Point(0, 0)
+        for point, weight in zip(reversed(history), weights):
+            p_sum = add_points(p_sum, scale_point(point, weight))
+
+        return p_sum
+
+    return process
+
 
 
 def mean_filter(size):
-	"""FIR filter with equal weights"""
-	return fir_filter([1/size]*size)
-	
-	
+    """FIR filter with equal weights"""
+    return fir_filter([1/size]*size)
+
+
 def exp_filter(percent):
-	"""IIR filter with the specified decay"""
-	prev = None
-	
-	def process(new_data):
-		nonlocal prev
-		
-		if prev is None:
-			prev = new_data
-		
-		new_point = add_points(
-			scale_point(prev, percent),
-			scale_point(new_data, 1.0 - percent)
-		)
-		prev = new_point
-		
-		return new_point
-		
-	return process 
+    """IIR filter with the specified decay"""
+    prev = None
+
+    def process(new_data):
+        nonlocal prev
+
+        if prev is None:
+            prev = new_data
+
+        new_point = add_points(
+            scale_point(prev, percent),
+            scale_point(new_data, 1.0 - percent)
+        )
+        prev = new_point
+
+        return new_point
+
+    return process
 
 
 def simple_predictive_filter(prediction_factor, velocity_smoothing_factor):
-	prev_prediction = None
-	est_velocity = Point(0, 0)
-	
-	def process(new_data):
-		nonlocal prev_prediction
-		nonlocal est_velocity
-		
-		if prev_prediction is None:
-			prev_prediction = new_data
+    prev_prediction = None
+    est_velocity = Point(0, 0)
 
-		current_velocity = add_points(new_data, invert_point(prev_prediction))
-		est_velocity = add_points(
-			scale_point(est_velocity, velocity_smoothing_factor),
-			scale_point(current_velocity, 1.0 - velocity_smoothing_factor)
-		)
+    def process(new_data):
+        nonlocal prev_prediction
+        nonlocal est_velocity
 
-		predicted_point = add_points(prev_prediction, est_velocity)
-		
-		smoothed_predicted_point = add_points(
-			scale_point(predicted_point, prediction_factor),
-			scale_point(prev_prediction, 1.0 - prediction_factor)
-		)
-		prev_prediction = smoothed_predicted_point
-		
-		return smoothed_predicted_point
-		
-	return process 
+        if prev_prediction is None:
+            prev_prediction = new_data
 
+        current_velocity = add_points(new_data, invert_point(prev_prediction))
+        est_velocity = add_points(
+            scale_point(est_velocity, velocity_smoothing_factor),
+            scale_point(current_velocity, 1.0 - velocity_smoothing_factor)
+        )
+
+        predicted_point = add_points(prev_prediction, est_velocity)
+
+        smoothed_predicted_point = add_points(
+            scale_point(predicted_point, prediction_factor),
+            scale_point(prev_prediction, 1.0 - prediction_factor)
+        )
+        prev_prediction = smoothed_predicted_point
+
+        return smoothed_predicted_point
+
+    return process
 
 def filter_array(fltr, points):
-	return tuple(fltr(p) for p in points)
-	
+    return tuple(fltr(p) for p in points)
+

--- a/main.py
+++ b/main.py
@@ -1,82 +1,196 @@
-import matplotlib.pyplot as plt
+import os
+import math
 from collections import namedtuple
+
+import matplotlib.pyplot as plt
 from point import *
 import filters
 import point_array
 import noise
-import os
-
-TestCase = namedtuple("TestCase", ["name", "filter"])
-
-def squared_difference(point_array_1, point_array_2):
-	assert len(point_array_1) == len(point_array_2)
-	squared_delta = 0
-	for p_id, p1 in enumerate(point_array_1):
-		p2 = point_array_2[p_id]
-		squared_delta += squared_dist_points(p1, p2)
-	return squared_delta / len(point_array_1)
 
 
-def run_and_plot_filter(noisy_shape, filtered_shape, shape, run_name, name):
-	
-	comparison = squared_difference(filtered_shape, shape)
-	
-	plt.clf()
-	
-	filtered_shape_x, filtered_shape_y = point_array.point_array_to_axis_arrays(filtered_shape)
-	shape_x, shape_y = point_array.point_array_to_axis_arrays(shape)
-	noisy_shape_x, noisy_shape_y = point_array.point_array_to_axis_arrays(noisy_shape)
-
-	plt.plot(shape_x, shape_y, 'g')
-	plt.gca().set_autoscale_on(False)
-	plt.plot(noisy_shape_x, noisy_shape_y, 'rx')
-	plt.plot(filtered_shape_x, filtered_shape_y, 'b')
-	plt.plot(filtered_shape_x[-1], filtered_shape_y[-1], 'bo', fillstyle='none')
-
-	plt.title(name + ' (Average Delta = {:.02f})'.format(comparison))
-	
-	directory = "output/{}".format(run_name)
-	if not os.path.exists(directory):
-		os.makedirs(directory)
-	plt.savefig("{}/{}.png".format(directory, name))
+TestFilter = namedtuple("TestCase", ["filter_name", "filter"])
+TestShape = namedtuple("TestShape", ["shape_name", "clean_shape", "noisy_shape"])
+TestResult = namedtuple("TestResult", ["shape", "filter", "filtered_array", "average_error"])
 
 
 def generate_box():
-	""" Generates a predetermined zigzag line that can be used to test """
-	points = []
-	points.extend(point_array.generate_line_segment(Point(0, 0), Point(0, 5), 20))
-	points.extend(point_array.generate_line_segment(Point(0, 5), Point(5, 5), 20))
-	points.extend(point_array.generate_line_segment(Point(5, 5), Point(5, 0), 20))
-	return points
+    """ Generates a predetermined zigzag line that can be used to test
+    the response to sharp corners"""
+    points = []
+    points.extend(point_array.generate_line_segment(Point(0, 0), Point(0, 5), 20))
+    points.extend(point_array.generate_line_segment(Point(0, 5), Point(5, 5), 20))
+    points.extend(point_array.generate_line_segment(Point(5, 5), Point(5, 0), 20))
+    return points
 
 
-def run_filters(shape, noisy_shape, run_name):
-	test_cases = [
-	  TestCase("No Filter", filters.null_filter()),
-	  TestCase("Reference (Median Filter 4 Samples)", filters.mean_filter(4))
-	]
-	for smoothing in [0.5, 0.8]:
-		for prediction in [0.5, 0.8]:
-			test_cases.append(
-			  TestCase("Predictive Filter (predict={}, smooth={})".format(prediction, smoothing),
-			           filters.simple_predictive_filter(prediction, smoothing))
-			)
-	for fc in [0.6]:
-		test_cases.append(
-		  TestCase("Exp Filter {}".format(fc), filters.exp_filter(fc))
-		)
+def generate_step():
+    """ Generates a single step to make it easy to check overshoot """
+    points = []
+    points.extend(point_array.generate_line_segment(Point(0, 0), Point(5, 0), 20))
+    points.extend(point_array.generate_line_segment(Point(5, 5), Point(10, 5), 20))
+    return points
 
-	for case in test_cases:
-		run_and_plot_filter(noisy_shape, filters.filter_array(case.filter, noisy_shape), shape, run_name, case.name)
+
+def generate_sine():
+    """ Generates a predetermined zigzag line that can be used to test
+    corner-cutting on a more natural shape """
+    points = []
+    for x in range(100):
+        points.append(Point(x/20, math.sin(x/20)*2.5 + 2.5))
+    return points
+
+
+def get_test_filters():
+    """ Returns some filters. These filters are run for each shape
+    returned by "get_test_shapes()". This function is called for
+    each run to prevent contamination """
+    test_filters = [
+        TestFilter("No Filter", filters.null_filter()),
+        TestFilter("Reference (Mean Filter 4 Samples)", filters.mean_filter(4)),
+        TestFilter("Exp Filter 0.6", filters.exp_filter(0.6)),
+        TestFilter("Predictive Filter (predict=0.6, smooth=0.6)",filters.simple_predictive_filter(0.6, 0.6))
+    ]
+
+    # It can be useful to iterate for a particular filter, eg:
+    # for filter_constant in [0.3, 0.6, 0.9]:
+    #    test_filters.append(TestFilter(
+    #        "Exp Filter {}".format(filter_constant, filters.exp_filter(filter_constant)),
+    #    ))
+
+    return test_filters
+
+
+def get_test_shapes():
+    """ Run each filter on these different steps. This makes it possible
+    to check filter response on different sets of input data """
+    box = generate_box()
+    step = generate_step()
+    sine = generate_sine()
+
+    test_shapes = [
+        TestShape("Box Clean", box, box),
+        TestShape("Step Clean", step, step),
+        TestShape("Sine Clean", sine, sine),
+    ]
+    for seed in range(3):
+        distortion_box = noise.generate_noise_array(noise.white_noise(seed, 0.2), len(box))
+        noisy_box = point_array.sum_point_arrays(distortion_box, box)
+        test_shapes.append(TestShape(
+            "Box seed={} Noise=0.2".format(seed),
+            box,
+            noisy_box
+        ))
+    for seed in range(3):
+        distortion_sine = noise.generate_noise_array(noise.white_noise(seed, 0.2), len(sine))
+        noisy_sine = point_array.sum_point_arrays(distortion_sine, sine)
+        test_shapes.append(TestShape(
+            "Sine seed={} Noise=0.2".format(seed),
+            sine,
+            noisy_sine
+        ))
+    return test_shapes
+
+
+def run_filters(test_shapes):
+    """ Generates and runs each filter on each of the provided shapes """
+    print("Starting Filtering")
+    results = []
+    count = 0
+    for shape in test_shapes:
+        for filt in get_test_filters(): # Recreate the filters for each shape
+            count += 1
+            print("Filtering {}".format(count), end='\r')
+            filtered_shape = filters.filter_array(filt.filter, shape.noisy_shape)
+            results.append(TestResult(
+                shape,
+                filt,
+                filtered_shape,
+                math.sqrt(point_array.squared_difference(filtered_shape, shape.clean_shape))
+            ))
+    print("Filtering Complete")
+    return results
+
+
+def plot_shapes(test_results):
+    """ Plots the test results grouping all the shapes onto the same
+    output image """
+    print("Plotting Shapes")
+    runs_by_shape = {}
+    for result in test_results:
+        shape_name = result.shape.shape_name
+        shape_array = runs_by_shape.get(shape_name, [])
+        shape_array.append(result)
+        runs_by_shape[shape_name] = shape_array
+
+    plot_runs("output/shapes", runs_by_shape)
+    print("Plotting Shapes Complete")
+
+
+
+def plot_filters(test_results):
+    """ Plots the test results grouping all the filters onto the same
+    output image """
+    print("Plotting Filters")
+    runs_by_filter = {}
+    for result in test_results:
+        filter_name = result.filter.filter_name
+        filter_array = runs_by_filter.get(filter_name, [])
+        filter_array.append(result)
+        runs_by_filter[filter_name] = filter_array
+
+    plot_runs("output/filters", runs_by_filter)
+    print("Plotting Filters Complete")
+
+
+def plot_runs(directory, runs):
+    total_num = len(runs)
+    count = 0
+    for run_name in runs:
+        count += 1
+        print("Plotting {}/{}".format(count, total_num), end='\r')
+        results = runs[run_name]
+
+        plot_width = math.ceil(math.sqrt(len(results)))
+        fig, axes = plt.subplots(plot_width, plot_width)
+        fig.set_size_inches(plot_width * 5, plot_width * 5)
+
+        for test_id, test_result in enumerate(results):
+            axis = axes[math.floor(test_id/plot_width)][test_id%plot_width]
+            plot_run(axis, test_result)
+
+
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+        plt.savefig("{}/{}.png".format(directory, run_name))
+
+
+def plot_run(axis, test_result):
+    """ Plots the supplied test onto the provided set of graph axis """
+    filtered_shape_x, filtered_shape_y = point_array.point_array_to_axis_arrays(test_result.filtered_array)
+    shape_x, shape_y = point_array.point_array_to_axis_arrays(test_result.shape.clean_shape)
+    noisy_shape_x, noisy_shape_y = point_array.point_array_to_axis_arrays(test_result.shape.noisy_shape)
+
+    axis.plot(shape_x, shape_y, 'g')
+    axis.set_autoscale_on(False)
+    axis.plot(noisy_shape_x, noisy_shape_y, 'rx')
+    axis.plot(filtered_shape_x, filtered_shape_y, 'b')
+    axis.plot(filtered_shape_x[-1], filtered_shape_y[-1], 'bo', fillstyle='none')
+    axis.text(1, 2, '(Average Delta = {:.02f})'.format(test_result.average_error))
+
+    axis.set_title("{}\n{}".format(
+        test_result.shape.shape_name,
+        test_result.filter.filter_name
+    ))
+
+
+def main():
+    test_shapes = get_test_shapes()
+    test_results = run_filters(test_shapes)
+
+    plot_shapes(test_results)
+    plot_filters(test_results)
 
 
 if __name__ == "__main__":
-	shape = generate_box()
-	
-	for seed in range(10):
-		distortion = noise.generate_noise_array(noise.white_noise(seed, 0.2), len(shape))
-		noisy_shape = point_array.sum_point_arrays(distortion, shape)
-		
-		run_filters(shape, noisy_shape, "seed={} Noise=0.2".format(seed))
-	
-	run_filters(shape, shape, "NoNoise")
+    main()

--- a/point_array.py
+++ b/point_array.py
@@ -1,4 +1,4 @@
-from point import Point, add_points, invert_point, scale_point
+from point import Point, add_points, invert_point, scale_point, squared_dist_points
 
 def point_array_to_axis_arrays(points):
 	""" Separates an array of points into two arrays: one of all the X
@@ -32,3 +32,13 @@ def generate_line_segment(start_point, end_point, steps):
 		current_point = add_points(start_point, current_delta)
 		points.append(current_point)
 	return points
+
+
+def squared_difference(point_array_1, point_array_2):
+    """ Returns the sum of squared error between two point arrays """
+    assert len(point_array_1) == len(point_array_2)
+    squared_delta = 0
+    for p_id, p1 in enumerate(point_array_1):
+        p2 = point_array_2[p_id]
+        squared_delta += squared_dist_points(p1, p2)
+    return squared_delta / len(point_array_1)


### PR DESCRIPTION
Previously the program would generate a separate image per filter and per shape. This made comparisons reasonably difficult. 

To aid comparison, this PR makes it generate one image per shape (which contains a run for each filter), and one image per filter (which contains the data for all the shapes). This makes it easier to:

 - Tune the performance of a single filter because you can see what effect is is having on all the different shapes at the same time
 - Compare multiple filters because you can see them all next to each other.


Example graph showing the performance of a single filter
![Exp Filter 0 6](https://user-images.githubusercontent.com/13490050/64905624-7031bb00-d6db-11e9-903f-44893201da86.png)

Example graph comparing all the filters on the same input:
![Step Clean](https://user-images.githubusercontent.com/13490050/64905633-8770a880-d6db-11e9-80c4-2955a9e3365b.png)

Because this PR makes it easier to review multiple shapes, it adds the following shapes:
 - Step response. 
 - Sine wave (smooth corners)


Finally, it converts tabs to spaces in the files that have been modified. I apologize for having my IDE set in tabs when I started this project. 