### PR TITLE
The reference filter now starts in the right position

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -20,7 +20,12 @@ def fir_filter(weights):
             history = history[-len(weights):]
 
         p_sum = Point(0, 0)
-        for point, weight in zip(reversed(history), weights):
+        
+        # Ensure the weights are normalized for the available history
+        normalized_weights =  weights[:len(history)]
+        normalized_weights = [w/sum(normalized_weights) for w in normalized_weights]
+        
+        for point, weight in zip(reversed(history), normalized_weights):
             p_sum = add_points(p_sum, scale_point(point, weight))
 
         return p_sum

--- a/test_filter.py
+++ b/test_filter.py
@@ -1,31 +1,42 @@
 from filters import *
 
 def test_fir_filter():
-	f = fir_filter([0.5, 0.2, 0.3])
-	assert f(Point(1, 0)) == Point(0.5, 0.0)
-	assert f(Point(0, 1)) == Point(0.2, 0.5)
-	assert f(Point(0, 1)) == Point(0.3, 0.7)
-	assert f(Point(0, 0)) == Point(0.0, 0.5)
-	assert f(Point(0, 0)) == Point(0.0, 0.3)
-	assert f(Point(0, 0)) == Point(0.0, 0.0)
+    f = fir_filter([0.5, 0.2, 0.3])
+    assert f(Point(0, 0)) == Point(0.0, 0.0)
+    assert f(Point(0, 0)) == Point(0.0, 0.0)
+    assert f(Point(0, 0)) == Point(0.0, 0.0)
+    assert f(Point(0, 0)) == Point(0.0, 0.0)
+    assert f(Point(1, 0)) == Point(0.5, 0.0)
+    assert f(Point(0, 1)) == Point(0.2, 0.5)
+    assert f(Point(0, 1)) == Point(0.3, 0.7)
+    assert f(Point(0, 0)) == Point(0.0, 0.5)
+    assert f(Point(0, 0)) == Point(0.0, 0.3)
+    assert f(Point(0, 0)) == Point(0.0, 0.0)
+
+
+def test_fir_filter_zero_start():
+    f = fir_filter([0.5, 0.2, 0.3])
+    assert f(Point(1, 0)) == Point(1.0, 0.0)
+
 
 def test_mean_filter():
-	f = mean_filter(4)
-	assert f(Point(1, 0)) == Point(0.25, 0.0)
-	assert f(Point(0, 1)) == Point(0.25, 0.25)
-	assert f(Point(0, 1)) == Point(0.25, 0.5)
-	assert f(Point(0, 0)) == Point(0.25, 0.5)
-	assert f(Point(0, 0)) == Point(0.0, 0.5)
-	assert f(Point(0, 0)) == Point(0.0, 0.25)
-	assert f(Point(0, 0)) == Point(0.0, 0.0)
+    f = mean_filter(4)
+    assert f(Point(0, 0)) == Point(0.0, 0.0)
+    assert f(Point(0, 0)) == Point(0.0, 0.0)
+    assert f(Point(0, 0)) == Point(0.0, 0.0)
+    assert f(Point(0, 0)) == Point(0.0, 0.0)
+    assert f(Point(1, 0)) == Point(0.25, 0.0)
+    assert f(Point(0, 1)) == Point(0.25, 0.25)
+    assert f(Point(0, 1)) == Point(0.25, 0.5)
+    assert f(Point(0, 0)) == Point(0.25, 0.5)
+    assert f(Point(0, 0)) == Point(0.0, 0.5)
+    assert f(Point(0, 0)) == Point(0.0, 0.25)
+    assert f(Point(0, 0)) == Point(0.0, 0.0)
 
 
 def test_exp_filter():
-	f = exp_filter(0.75)
-	assert f(Point(1, 0)) == Point(0.25, 0.0)
-	assert f(Point(0, 1)) == Point(0.1875, 0.25)
-	assert f(Point(0, 1)) == Point(0.140625, 0.4375)
-	assert f(Point(0, 1)) == Point(0.10546875, 0.578125)
-	assert f(Point(0, 1)) == Point(0.0791015625, 0.68359375)
-	assert f(Point(0, 1)) == Point(0.059326171875, 0.7626953125)
-	assert f(Point(0, 1)) == Point(0.04449462890625, 0.822021484375)
+    f = exp_filter(0.75)
+    assert f(Point(1, 0)) == Point(1.0, 0.0)
+    assert f(Point(0, 0)) == Point(0.75, 0.0)
+    assert f(Point(0, 1)) == Point(0.5625, 0.25)
+    assert f(Point(0, 1)) == Point(0.421875, 0.4375)


### PR DESCRIPTION
The weights are normalized for the available history. If you had a FIR with non-normalized
weights, this will influence the result, but other than that it shouldn't make a difference